### PR TITLE
use https for baseURL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "http://blog.japaric.io/"
+baseURL = "https://blog.japaric.io/"
 copyright = "<a rel=\"license\" href=\"http://creativecommons.org/licenses/by/4.0/\"><img alt=\"Creative Commons License\" src=\"https://i.creativecommons.org/l/by/4.0/80x15.png\" /></a><br/>Jorge Aparicio"
 enableEmoji = true
 googleAnalytics = "UA-87779174-3"


### PR DESCRIPTION
Many websites use https instead of http and many web browsers auto have an auto fill feature
by default. Additionally, if content is loaded from an https connection using http the browsers
will often block that content. This leads to incomplete content loading (e.g. css styles) on the final
web page.

Need to load content (e.g. styles.css) over https to prevent browsers from blocking that content